### PR TITLE
Add vim.UI.select support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ tmux-switch.nvim/
 ## Installation :star: <a name="installation"></a> ##
  * Make sure you have Neovim v0.9.0 or greater. :exclamation:
  * Dependecies: nui && telescope && plenary (telescope dep)
+   + can be used without telescope, when the config option `not_use_telescope` is set to true. Then `vim.ui.select` is used.
  * Install using you plugin manager
 
 

--- a/lua/tmux-switch/commands.lua
+++ b/lua/tmux-switch/commands.lua
@@ -9,14 +9,13 @@
 -- File: commands.lua
 -- Author: Josip Keresman
 
-
 local tmux = require("tmux-switch.tmux")
 
 local M = {}
 
-function M.register()
+function M.register(config)
     vim.api.nvim_create_user_command("TmuxSwitch", function()
-        tmux.switch()
+        tmux.switch(config)
     end, {
         desc = "Run tmux switch picker",
     })

--- a/lua/tmux-switch/init.lua
+++ b/lua/tmux-switch/init.lua
@@ -9,13 +9,12 @@
 -- File: init.lua
 -- Author: Josip Keresman
 
-
 local commands = require("tmux-switch.commands")
 
 local M = {}
 
-function M.setup()
-    commands.register()
+function M.setup(config)
+    commands.register(config)
 end
 
 return M

--- a/lua/tmux-switch/tmux.lua
+++ b/lua/tmux-switch/tmux.lua
@@ -9,15 +9,14 @@
 -- File: tmux.lua
 -- Author: Josip Keresman
 
-
 local ui = require("tmux-switch.ui")
 local util = require("tmux-switch.util")
 
 local M = {}
 
-function M.switch()
+function M.switch(config)
     local tmux_sessions = util.get_tmux_sessions()
-    ui.show_tmux_session_picker(tmux_sessions)
+    ui.show_tmux_session_picker(tmux_sessions, config.not_use_telescope)
 end
 
 function M.create_session()

--- a/lua/tmux-switch/ui.lua
+++ b/lua/tmux-switch/ui.lua
@@ -9,7 +9,6 @@
 -- File: ui.lua
 -- Author: Josip Keresman
 
-
 local util = require("tmux-switch.util")
 
 local actions = require("telescope.actions")
@@ -63,37 +62,48 @@ function M.create_input_prompt(prompt_text, default_value, on_submit)
     end)
 end
 
---- Displays a tmux session picker using Telescope
+--- Displays a tmux session picker using Telescope or vim.ui.select
 --
 -- @param tmux_sessions A list of tmux sessions to display in the picker
+-- @param not_use_telescope A boolean indicating whether to use vim.ui.select instead of Telescope (default: false)
 --
-function M.show_tmux_session_picker(tmux_sessions)
-    local opts = themes.get_dropdown({
-        layout_config = { width = 50 },
-    })
-
-    pickers
-        .new(opts, {
-            prompt_title = "TMUX switch",
-
-            finder = finders.new_table({
-                results = tmux_sessions,
-            }),
-
-            sorter = sorters.get_generic_fuzzy_sorter(opts),
-
-            attach_mappings = function(prompt_bufnr)
-                actions.select_default:replace(function()
-                    actions.close(prompt_bufnr)
-                    local selected_session = action_state.get_selected_entry()
-                    if selected_session then
-                        util.switch_to_session(selected_session.value)
-                    end
-                end)
-                return true
-            end,
+function M.show_tmux_session_picker(tmux_sessions, not_use_telescope)
+    if not_use_telescope then
+        vim.ui.select(tmux_sessions, {
+            prompt = "Select TMUX session:",
+        }, function(selected_session)
+            if selected_session then
+                util.switch_to_session(selected_session)
+            end
+        end)
+    else
+        local opts = themes.get_dropdown({
+            layout_config = { width = 50 },
         })
-        :find()
+
+        pickers
+            .new(opts, {
+                prompt_title = "TMUX switch",
+
+                finder = finders.new_table({
+                    results = tmux_sessions,
+                }),
+
+                sorter = sorters.get_generic_fuzzy_sorter(opts),
+
+                attach_mappings = function(prompt_bufnr)
+                    actions.select_default:replace(function()
+                        actions.close(prompt_bufnr)
+                        local selected_session = action_state.get_selected_entry()
+                        if selected_session then
+                            util.switch_to_session(selected_session.value)
+                        end
+                    end)
+                    return true
+                end,
+            })
+            :find()
+    end
 end
 
 return M

--- a/lua/tmux-switch/ui.lua
+++ b/lua/tmux-switch/ui.lua
@@ -11,13 +11,6 @@
 
 local util = require("tmux-switch.util")
 
-local actions = require("telescope.actions")
-local action_state = require("telescope.actions.state")
-local finders = require("telescope.finders")
-local pickers = require("telescope.pickers")
-local sorters = require("telescope.sorters")
-local themes = require("telescope.themes")
-
 local nui_input = require("nui.input")
 local event = require("nui.utils.autocmd").event
 
@@ -77,6 +70,13 @@ function M.show_tmux_session_picker(tmux_sessions, not_use_telescope)
             end
         end)
     else
+        local actions = require("telescope.actions")
+        local action_state = require("telescope.actions.state")
+        local finders = require("telescope.finders")
+        local pickers = require("telescope.pickers")
+        local sorters = require("telescope.sorters")
+        local themes = require("telescope.themes")
+
         local opts = themes.get_dropdown({
             layout_config = { width = 50 },
         })


### PR DESCRIPTION
# Add vim.ui.select support

## Overview
This PR adds the option to not use telescope, instead the default vim.ui.select select can be used, which allows for example the usage of Snacks.picker. It adds the config option `not_use_telescope` to disable telescope.

## Changes
- Added option to use `vim.ui.select` instead of Telescope (145bb62)
- Refactored Telescope imports in `ui.lua` (ca8a48b)
- Passed config to commands and tmux (d307ebd)
