### PR TITLE
Sort by recent use

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ tmux-switch.nvim/
 - [x] Fuzzy find trough all tmux session and navigate to selected one
 - [x] Floating UI for creating new sessions
 - [x] Floating UI for renaming current session
-- [ ] Quick switch between 2 most used sessions
+- [ ] Quick switch between 2 most used sessions (works when the `sort_by_recent_use` option is set to true, then just enter the `:TmuxSwitch` command and select the first one)
 ***
 
 ## Installation :star: <a name="installation"></a> ##

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ tmux-switch.nvim/
 ## Installation :star: <a name="installation"></a> ##
  * Make sure you have Neovim v0.9.0 or greater. :exclamation:
  * Dependecies: nui && telescope && plenary (telescope dep)
+   + can be used without telescope, when the config option `not_use_telescope` is set to true. Then `vim.ui.select` is used.
  * Install using you plugin manager
 
 

--- a/lua/tmux-switch/commands.lua
+++ b/lua/tmux-switch/commands.lua
@@ -9,14 +9,13 @@
 -- File: commands.lua
 -- Author: Josip Keresman
 
-
 local tmux = require("tmux-switch.tmux")
 
 local M = {}
 
-function M.register()
+function M.register(config)
     vim.api.nvim_create_user_command("TmuxSwitch", function()
-        tmux.switch()
+        tmux.switch(config)
     end, {
         desc = "Run tmux switch picker",
     })

--- a/lua/tmux-switch/init.lua
+++ b/lua/tmux-switch/init.lua
@@ -9,13 +9,12 @@
 -- File: init.lua
 -- Author: Josip Keresman
 
-
 local commands = require("tmux-switch.commands")
 
 local M = {}
 
-function M.setup()
-    commands.register()
+function M.setup(config)
+    commands.register(config)
 end
 
 return M

--- a/lua/tmux-switch/tmux.lua
+++ b/lua/tmux-switch/tmux.lua
@@ -15,7 +15,7 @@ local util = require("tmux-switch.util")
 local M = {}
 
 function M.switch(config)
-    local tmux_sessions = util.get_tmux_sessions()
+    local tmux_sessions = util.get_tmux_sessions(config)
     ui.show_tmux_session_picker(tmux_sessions, config.not_use_telescope)
 end
 

--- a/lua/tmux-switch/tmux.lua
+++ b/lua/tmux-switch/tmux.lua
@@ -9,15 +9,14 @@
 -- File: tmux.lua
 -- Author: Josip Keresman
 
-
 local ui = require("tmux-switch.ui")
 local util = require("tmux-switch.util")
 
 local M = {}
 
-function M.switch()
+function M.switch(config)
     local tmux_sessions = util.get_tmux_sessions()
-    ui.show_tmux_session_picker(tmux_sessions)
+    ui.show_tmux_session_picker(tmux_sessions, config.not_use_telescope)
 end
 
 function M.create_session()

--- a/lua/tmux-switch/ui.lua
+++ b/lua/tmux-switch/ui.lua
@@ -9,7 +9,6 @@
 -- File: ui.lua
 -- Author: Josip Keresman
 
-
 local util = require("tmux-switch.util")
 
 local actions = require("telescope.actions")
@@ -63,37 +62,48 @@ function M.create_input_prompt(prompt_text, default_value, on_submit)
     end)
 end
 
---- Displays a tmux session picker using Telescope
+--- Displays a tmux session picker using Telescope or vim.ui.select
 --
 -- @param tmux_sessions A list of tmux sessions to display in the picker
+-- @param not_use_telescope A boolean indicating whether to use vim.ui.select instead of Telescope (default: false)
 --
-function M.show_tmux_session_picker(tmux_sessions)
-    local opts = themes.get_dropdown({
-        layout_config = { width = 50 },
-    })
-
-    pickers
-        .new(opts, {
-            prompt_title = "TMUX switch",
-
-            finder = finders.new_table({
-                results = tmux_sessions,
-            }),
-
-            sorter = sorters.get_generic_fuzzy_sorter(opts),
-
-            attach_mappings = function(prompt_bufnr)
-                actions.select_default:replace(function()
-                    actions.close(prompt_bufnr)
-                    local selected_session = action_state.get_selected_entry()
-                    if selected_session then
-                        util.switch_to_session(selected_session.value)
-                    end
-                end)
-                return true
-            end,
+function M.show_tmux_session_picker(tmux_sessions, not_use_telescope)
+    if not_use_telescope then
+        vim.ui.select(tmux_sessions, {
+            prompt = "Select TMUX session:",
+        }, function(selected_session)
+            if selected_session then
+                util.switch_to_session(selected_session)
+            end
+        end)
+    else
+        local opts = themes.get_dropdown({
+            layout_config = { width = 50 },
         })
-        :find()
+
+        pickers
+            .new(opts, {
+                prompt_title = "TMUX switch",
+
+                finder = finders.new_table({
+                    results = tmux_sessions,
+                }),
+
+                sorter = sorters.get_generic_fuzzy_sorter(opts),
+
+                attach_mappings = function(prompt_bufnr)
+                    actions.select_default:replace(function()
+                        actions.close(prompt_bufnr)
+                        local selected_session = action_state.get_selected_entry()
+                        if selected_session then
+                            util.switch_to_session(selected_session.value)
+                        end
+                    end)
+                    return true
+                end,
+            })
+            :find()
+    end
 end
 
 return M

--- a/lua/tmux-switch/ui.lua
+++ b/lua/tmux-switch/ui.lua
@@ -11,13 +11,6 @@
 
 local util = require("tmux-switch.util")
 
-local actions = require("telescope.actions")
-local action_state = require("telescope.actions.state")
-local finders = require("telescope.finders")
-local pickers = require("telescope.pickers")
-local sorters = require("telescope.sorters")
-local themes = require("telescope.themes")
-
 local nui_input = require("nui.input")
 local event = require("nui.utils.autocmd").event
 
@@ -77,6 +70,13 @@ function M.show_tmux_session_picker(tmux_sessions, not_use_telescope)
             end
         end)
     else
+        local actions = require("telescope.actions")
+        local action_state = require("telescope.actions.state")
+        local finders = require("telescope.finders")
+        local pickers = require("telescope.pickers")
+        local sorters = require("telescope.sorters")
+        local themes = require("telescope.themes")
+
         local opts = themes.get_dropdown({
             layout_config = { width = 50 },
         })

--- a/lua/tmux-switch/util.lua
+++ b/lua/tmux-switch/util.lua
@@ -17,7 +17,6 @@ local M = {}
 function M.get_tmux_sessions(config)
     local list_tmux_sessions_cmd
     if config and config.sort_by_recent_use then
-        vim.notify("sort by recent use")
         list_tmux_sessions_cmd =
             "tmux ls -F '#{session_last_attached} #{session_name}' | sort -nr | awk '{print $2}'"
     else
@@ -33,9 +32,16 @@ function M.get_tmux_sessions(config)
     local tmux_ls_results = handle:read("*a")
     handle:close()
 
+    local current_session_cmd = "tmux display-message -p '#S'"
+    local handle_current = io.popen(current_session_cmd)
+    local current_session = handle_current:read("*a"):gsub("\n", "")
+    handle_current:close()
+
     local tmux_sessions = {}
     for session in string.gmatch(tmux_ls_results, "[^\n]+") do
-        table.insert(tmux_sessions, session)
+        if session ~= current_session then
+            table.insert(tmux_sessions, session)
+        end
     end
 
     return tmux_sessions

--- a/lua/tmux-switch/util.lua
+++ b/lua/tmux-switch/util.lua
@@ -9,14 +9,20 @@
 -- File: util.lua
 -- Author: Josip Keresman
 
-
 local M = {}
 
 -- Retrieves the list of available tmux sessions
 --
 -- @return A table containing the names of tmux sessions, or an empty table if an error occurs
-function M.get_tmux_sessions()
-    local list_tmux_sessions_cmd = "tmux ls | awk -F ':' '{print $1}'"
+function M.get_tmux_sessions(config)
+    local list_tmux_sessions_cmd
+    if config and config.sort_by_recent_use then
+        vim.notify("sort by recent use")
+        list_tmux_sessions_cmd =
+            "tmux ls -F '#{session_last_attached} #{session_name}' | sort -nr | awk '{print $2}'"
+    else
+        list_tmux_sessions_cmd = "tmux ls | awk -F ':' '{print $1}'"
+    end
     local handle = io.popen(list_tmux_sessions_cmd)
 
     if not handle then


### PR DESCRIPTION
# Overview
This adds the option to sort the sessions by recent use. This can be turned on with the `sort_by_recent_use` flag in the options.

## Changes
- Passed config to `util.get_tmux_sessions` (4ebc2c5)
- Removed current session from list (51e67c8)
